### PR TITLE
Increase cURL timeout to 30s to match Wallabag settings

### DIFF
--- a/wallabag_v2/init.php
+++ b/wallabag_v2/init.php
@@ -3,7 +3,7 @@ class Wallabag_v2 extends Plugin {
 	private $host;
 
 	function about() {
-		return array("1.3.1",
+		return array("1.3.2",
 			"Post articles to a Wallabag v 2.x instance",
 			"joshu@unfettered.net");
 	}
@@ -198,7 +198,7 @@ class Wallabag_v2 extends Plugin {
 					curl_setopt($cURL, CURLOPT_HEADER, 1);
 					curl_setopt($cURL, CURLOPT_HTTPHEADER, array('Content-type: application/x-www-form-urlencoded;charset=UTF-8'));
 					curl_setopt($cURL, CURLOPT_RETURNTRANSFER, true);
-					curl_setopt($cURL, CURLOPT_TIMEOUT, 5);
+					curl_setopt($cURL, CURLOPT_TIMEOUT, 30);
 					curl_setopt($cURL, CURLOPT_POST, 4);
 					curl_setopt($cURL, CURLOPT_POSTFIELDS, http_build_query($postfields));
 				$apicall = curl_exec($cURL);


### PR DESCRIPTION
I'm using Wallabag to save really long articles and I have enabled the Wallabag feature "Download and save articles images locally" which increases download time a lot. Current Wallabag timeout for download an article is 30s.
![imagen](https://user-images.githubusercontent.com/10577978/37864072-bb23d6ae-2f69-11e8-879c-aa391ef390d7.png)

Example article => https://neilpatel.com/es/blog/por-que-los-articulos-de-blog-con-3000-palabras-generan-mas-trafico-una-respuesta-basada-en-datos/
